### PR TITLE
Missing HTML files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='BSD',
     packages=['adminplus'],
     include_package_data=True,
-    package_data = {'': ['README.rst']},
+    package_data = {'': ['README.rst', 'templates/adminplus/*.html']},
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hi,

I added html files to setup.py. Using this command : python setup.py install , html files were not copied, only py files and the README file.

Best,
Fabien
