### PR TITLE
Version on PyPI still does not include templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.rst
+recursive-include adminplus/templates/adminplus *.html


### PR DESCRIPTION
Hi,

If I `pip install django-adminplus` from PyPI, I still don't get the templates (despite 28aedcfa89b67be420a9dedd496b64c03fdc480c ).

I think this is because of a bug in Python: http://bugs.python.org/issue2279

Anyway, I've added the templates to the `MANIFEST.in` file. Hopefully this should fix it!
