### PR TITLE
custom_list.append bug fixed

### DIFF
--- a/adminplus/__init__.py
+++ b/adminplus/__init__.py
@@ -46,7 +46,7 @@ class AdminSitePlus(AdminSite):
                 if name:
                     custom_list.append((path, name))
                 else:
-                    custom_list.append(path, capfirst(view.__name__))
+                    custom_list.append((path, capfirst(view.__name__)))
 
         # Sort views alphabetically.
         custom_list.sort(key=lambda x: x[1])


### PR DESCRIPTION
In tag 0.1.6 there is a bug in **init**.py at line 49 that cause a error if you don't specify the view name: you are appending 2 values instead of a tuple. This commit fix it.
