### PR TITLE
Fixing setup.py imports

### DIFF
--- a/adminplus/__init__.py
+++ b/adminplus/__init__.py
@@ -1,13 +1,6 @@
-from __future__ import absolute_import
-
-try:
-    from .sites import AdminSitePlus
-
-    site = AdminSitePlus()
-except ImportError:
-    pass
-
+'''
+Django-AdminPlus module
+'''
 
 VERSION = (0, 2, 'dev')
 __version__ = '.'.join(map(str, VERSION))
-__all__ = ['AdminSitePlus', 'site']

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 
 import adminplus
 
-
 setup(
     name='django-adminplus',
     version=adminplus.__version__,


### PR DESCRIPTION
If django is already installed you get an App Not Configured
Exception because of the adminplus import in setup.py
