### PR TITLE
fix a Django >= 1.5 bug extending adminplus/base

### DIFF
--- a/adminplus/templates/adminplus/base.html
+++ b/adminplus/templates/adminplus/base.html
@@ -2,6 +2,6 @@
 
 {% block breadcrumbs %}
   <div class="breadcrumbs">
-    <a href="{% url admin:index %}">Home</a> &rsaquo; {{ title }}
+    <a href="{% url 'admin:index' %}">Home</a> &rsaquo; {{ title }}
   </div>
 {% endblock %}


### PR DESCRIPTION
- error shown:
  `Could not parse the remainder: ':index' from 'admin:index'. The syntax of 'url' changed in Django 1.5, see the docs.`
- adding quotes seems to fix the problem
- see http://stackoverflow.com/a/8789892/305019
