### PR TITLE
Give priority to custom views over generic matching patterns on AdminSite.

### DIFF
--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -39,10 +39,10 @@ class AdminPlusMixin(object):
         urls = super(AdminPlusMixin, self).get_urls()
         from django.conf.urls import patterns, url
         for path, view, name, urlname, visible in self.custom_views:
-            urls += patterns(
+            urls = patterns(
                 '',
                 url(r'^%s$' % path, self.admin_view(view), name=urlname),
-            )
+            ) + urls
         return urls
 
     def index(self, request, extra_context=None):


### PR DESCRIPTION
I am not sure on what Django version this became an issue, but my custom view, with URL "insertion_report/", was not reached, because Django matched the request with:

```
        url(r'^(?P<app_label>\w+)/$',
            wrap(self.app_index),
            name='app_list')
```

(contrib/admin/sites.py:238, on Django 1.6.1)

that came first in the urlpatterns chain.
