### PR TITLE
Allow to register a class based view

### DIFF
--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -1,5 +1,10 @@
 from django.contrib.admin.sites import AdminSite
 from django.utils.text import capfirst
+from django.views.generic import View
+import inspect
+
+def is_class_based_view(view):
+    return inspect.isclass(view) and issubclass(view, View)
 
 
 class AdminPlusMixin(object):
@@ -26,10 +31,14 @@ class AdminPlusMixin(object):
         * `view` is any view function you can imagine.
         """
         if view is not None:
+            if is_class_based_view(view):
+                view = view.as_view()
             self.custom_views.append((path, view, name, urlname, visible))
             return
 
         def decorator(fn):
+            if is_class_based_view(fn):
+                fn = fn.as_view()
             self.custom_views.append((path, fn, name, urlname, visible))
             return fn
         return decorator

--- a/adminplus/tests.py
+++ b/adminplus/tests.py
@@ -1,5 +1,6 @@
 from django.template.loader import render_to_string
 from django.test import TestCase
+from django.views.generic import View
 
 from adminplus.sites import AdminSitePlus
 
@@ -12,9 +13,15 @@ class AdminPlusTests(TestCase):
         @site.register_view(r'foo/bar')
         def foo_bar(request):
             return 'foo-bar'
-
+        
+        @site.register_view(r'foobar')
+        class FooBar(View):
+            def get(self, request):
+                return 'foo-bar'
+        
         urls = site.get_urls()
         assert any(u.resolve('foo/bar') for u in urls)
+        assert any(u.resolve('foobar') for u in urls)
 
     def test_function(self):
         """register_view works as a function."""
@@ -23,9 +30,15 @@ class AdminPlusTests(TestCase):
         def foo(request):
             return 'foo'
         site.register_view('foo', view=foo)
+        
+        class Foo(View):
+            def get(self, request):
+                return 'foo'
+        site.register_view('bar', view=Foo)
 
         urls = site.get_urls()
         assert any(u.resolve('foo') for u in urls)
+        assert any(u.resolve('bar') for u in urls)
 
     def test_path(self):
         """Setting the path works correctly."""


### PR DESCRIPTION
Add support to `adminplus.sites.register_view` for class based views

``` python
class MyView(View):
    def get(self, request):
        ...
    def post(self, request):
        ...

admin.site.register_view('somepath', view=MyView)
```
