### PR TITLE
Add middleware to test_settings to remove warning in django 1.7.

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -17,3 +17,4 @@ DATABASES = {
 }
 
 ROOT_URLCONF = 'test_urlconf'
+MIDDLEWARE_CLASSES = ()


### PR DESCRIPTION
Add MIDDLEWARE_CLASSES in order to get rid of these warnings when running on django 1.7

System check identified some issues:

WARNINGS:
?: (1_7.W001) MIDDLEWARE_CLASSES is not set.
	HINT: Django 1.7 changed the global defaults for the MIDDLEWARE_CLASSES. django.contrib.sessions.middleware.SessionMiddleware, django.contrib.auth.middleware.AuthenticationMiddleware, and django.contrib.messages.middleware.MessageMiddleware were removed from the defaults. If your project needs these middleware then you should configure this setting.
