### PR TITLE
Allow `visible` to be a predicate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ You can also use ``register_view`` as a decorator::
 
 * ``urlname``: give a name to the urlpattern so it can be called by 
   ``redirect()``, ``reverse()``, etc.
-* `visible`: a boolean that defines if the custom view is visible in the admin
-  dashboard.
+* `visible`: a boolean or a callable returning one, that defines if
+  the custom view is visible in the admin dashboard.
 
 All registered views are wrapped in ``admin.site.admin_view``.
 

--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -31,17 +31,14 @@ class AdminPlusMixin(object):
             the custom view should be visible in the admin dashboard or not.
         * `view` is any view function you can imagine.
         """
-        if view is not None:
-            if is_class_based_view(view):
-                view = view.as_view()
-            self.custom_views.append((path, view, name, urlname, visible))
-            return
-
         def decorator(fn):
             if is_class_based_view(fn):
                 fn = fn.as_view()
             self.custom_views.append((path, fn, name, urlname, visible))
             return fn
+        if view is not None:
+            decorator(view)
+            return
         return decorator
 
     def get_urls(self):

--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -27,8 +27,8 @@ class AdminPlusMixin(object):
             empty, we'll guess based on view.__name__.
         * `urlname` is an optional parameter to be able to call the view with a
             redirect() or reverse()
-        * `visible` is a boolean to set if the custom view should be visible in
-            the admin dashboard or not.
+        * `visible` is a boolean or predicate returning one, to set if
+            the custom view should be visible in the admin dashboard or not.
         * `view` is any view function you can imagine.
         """
         if view is not None:
@@ -61,7 +61,9 @@ class AdminPlusMixin(object):
             extra_context = {}
         custom_list = []
         for path, view, name, urlname, visible in self.custom_views:
-            if visible is True:
+            if callable(visible):
+                visible = visible(request)
+            if visible:
                 if name:
                     custom_list.append((path, name))
                 else:


### PR DESCRIPTION
Hello,

I thought it would be a good idea to allow showing on hiding views on per-request basis. This way I was able to show or hide pages based on users' permissions, e.g.:

    class MyAdminView(MyCheckRequestMixin, View):
        @classmethod
        def check_request(cls, request, *args, **kwargs):
            return request.user.has_perm("foo.change_bar")
        ...

    admin.site.register_view("my-view", _(u"My view"),
        view=MyAdminView.as_view(), visible=MyAdminView.check_request)

The change is quite simple and backwards-compatible.

There is a second commit that refactors `register_view` function a bit, removing duplicate code. Initially I've had an idea of a special `visibility=INTROSPECT` option for automagical introspection of the the view function, searching for `user_passes_test` decorators, but this was too fragile, so I decided against this. Yet, I already did the commit, and I thought maybe you'd like it. Sorry if that's excessive.

Thanks!