### PR TITLE
List of url() instead of using patterns()

### DIFF
--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -44,12 +44,11 @@ class AdminPlusMixin(object):
     def get_urls(self):
         """Add our custom views to the admin urlconf."""
         urls = super(AdminPlusMixin, self).get_urls()
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
         for path, view, name, urlname, visible in self.custom_views:
-            urls = patterns(
-                '',
+            urls = [
                 url(r'^%s$' % path, self.admin_view(view), name=urlname),
-            ) + urls
+            ] + urls
         return urls
 
     def index(self, request, extra_context=None):


### PR DESCRIPTION
Django 1.10 removes the old `patterns()` way to define URLs. This complies with the deprecation notice recommendation:

>adminplus/sites.py:51: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.