### PR TITLE
Added kwargs to register_view()

### DIFF
--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -18,7 +18,7 @@ class AdminPlusMixin(object):
         return super(AdminPlusMixin, self).__init__(*args, **kwargs)
 
     def register_view(self, path, name=None, urlname=None, visible=True,
-                      view=None):
+                      view=None, **kwargs):
         """Add a custom admin view. Can be used as a function or a decorator.
 
         * `path` is the path in the admin where the view will live, e.g.
@@ -34,7 +34,7 @@ class AdminPlusMixin(object):
         def decorator(fn):
             if is_class_based_view(fn):
                 fn = fn.as_view()
-            self.custom_views.append((path, fn, name, urlname, visible))
+            self.custom_views.append((path, fn, name, urlname, visible, kwargs))
             return fn
         if view is not None:
             decorator(view)
@@ -45,7 +45,7 @@ class AdminPlusMixin(object):
         """Add our custom views to the admin urlconf."""
         urls = super(AdminPlusMixin, self).get_urls()
         from django.conf.urls import url
-        for path, view, name, urlname, visible in self.custom_views:
+        for path, view, name, urlname, visible, kwargs in self.custom_views:
             urls = [
                 url(r'^%s$' % path, self.admin_view(view), name=urlname),
             ] + urls
@@ -56,14 +56,14 @@ class AdminPlusMixin(object):
         if not extra_context:
             extra_context = {}
         custom_list = []
-        for path, view, name, urlname, visible in self.custom_views:
+        for path, view, name, urlname, visible, kwargs in self.custom_views:
             if callable(visible):
                 visible = visible(request)
             if visible:
                 if name:
-                    custom_list.append((path, name))
+                    custom_list.append((path, name, kwargs))
                 else:
-                    custom_list.append((path, capfirst(view.__name__)))
+                    custom_list.append((path, capfirst(view.__name__), kwargs))
 
         # Sort views alphabetically.
         custom_list.sort(key=lambda x: x[1])

--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -62,9 +62,10 @@ class AdminPlusMixin(object):
                 visible = visible(request)
             if visible:
                 if name:
-                    custom_list.append((path, name, kwargs))
+                    custom_list.append((path, name, urlname, kwargs))
                 else:
-                    custom_list.append((path, capfirst(view.__name__), kwargs))
+                    custom_list.append(
+                        (path, capfirst(view.__name__), urlname, kwargs))
 
         # Sort views alphabetically.
         custom_list.sort(key=lambda x: x[1])

--- a/adminplus/sites.py
+++ b/adminplus/sites.py
@@ -34,7 +34,8 @@ class AdminPlusMixin(object):
         def decorator(fn):
             if is_class_based_view(fn):
                 fn = fn.as_view()
-            self.custom_views.append((path, fn, name, urlname, visible, kwargs))
+            self.custom_views.append(
+                (path, fn, name, urlname, visible, kwargs))
             return fn
         if view is not None:
             decorator(view)


### PR DESCRIPTION
This allows passing `kwargs` to the `register_view()` and then this dictionary is accessible as a 3rd item in the `custom_list` tuples.

Currently no tests added, we use it internally so would like to know if there's a general interest.